### PR TITLE
Migrate Android NDK to r29, update GHA and macos-latest

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -14,7 +14,7 @@ jobs:
     timeout-minutes: 30
     strategy:
       matrix:
-        os: [windows-latest, ubuntu-latest, macos-13]
+        os: [windows-latest, ubuntu-latest, macos-latest]
         abi: [x86_64, x86, arm64-v8a, armeabi-v7a]
     runs-on: ${{matrix.os}}
 
@@ -33,7 +33,7 @@ jobs:
           "https://github.com/ninja-build/ninja/releases/download/v1.11.1/ninja-$suffix.zip"
         unzip ninja.zip -d "$HOME/bin"
 
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         submodules: true
         lfs: true
@@ -51,7 +51,7 @@ jobs:
       shell: bash
       run: cmake --install build/${{matrix.abi}}
     - name: Archive artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: android-${{matrix.os}}-${{matrix.abi}}
         path: ~/android/
@@ -60,7 +60,7 @@ jobs:
     timeout-minutes: 30
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-13]
+        os: [ubuntu-latest, macos-15-intel]
         abi: [x86_64]
     runs-on: ${{matrix.os}}
 
@@ -76,7 +76,7 @@ jobs:
           | sudo tee /etc/udev/rules.d/99-kvm4all.rules
         sudo udevadm control --reload-rules
         sudo udevadm trigger --name-match=kvm
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         submodules: true
         lfs: true
@@ -85,7 +85,7 @@ jobs:
     - name: Build ${{matrix.abi}}
       run: cmake --build build/${{matrix.abi}} -v
     - name: AVD cache
-      uses: actions/cache@v3
+      uses: actions/cache@v5
       id: avd-cache
       with:
         path: |
@@ -99,7 +99,7 @@ jobs:
         emulator-options: -no-window -gpu swiftshader_indirect -no-audio -no-boot-anim -camera-back none
         api-level: 21
         arch: ${{matrix.abi}}
-        ndk: 25.2.9519653
+        ndk: 29.0.14206865
         force-avd-creation: false
         disable-animations: false
         script: echo "Generated AVD snapshot for caching."
@@ -109,12 +109,12 @@ jobs:
         emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -no-audio -no-boot-anim -camera-back none
         api-level: 21
         arch: ${{matrix.abi}}
-        ndk: 25.2.9519653
+        ndk: 29.0.14206865
         force-avd-creation: false
         disable-animations: true
         script: sh android.sh build test ${{matrix.abi}}
     - name: Archive artifacts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v7
       with:
         name: android-testsuite-${{matrix.os}}-${{matrix.abi}}
         path: build/${{matrix.abi}}/testsuite/log.txt

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -8,6 +8,7 @@ on:
 
 env:
   BUILD_TYPE: Release
+  NDK_VERSION: 29.0.14206865
 
 jobs:
   build:
@@ -19,6 +20,8 @@ jobs:
     runs-on: ${{matrix.os}}
 
     steps:
+    - name: Set ANDROID_NDK path
+      run: echo "ANDROID_NDK=$ANDROID_HOME/ndk/$NDK_VERSION" >> $GITHUB_ENV
     - name: Set up on Windows
       if: runner.os == 'Windows'
       shell: bash
@@ -65,6 +68,8 @@ jobs:
     runs-on: ${{matrix.os}}
 
     steps:
+    - name: Set ANDROID_NDK path
+      run: echo "ANDROID_NDK=$ANDROID_HOME/ndk/$NDK_VERSION" >> $GITHUB_ENV
     # https://github.blog/changelog/2023-02-23-hardware-accelerated-android-virtualization-on-actions-windows-and-linux-larger-hosted-runners/
     # https://github.blog/2024-01-17-github-hosted-runners-double-the-power-for-open-source/
     - name: Enable KVM group perms
@@ -99,7 +104,7 @@ jobs:
         emulator-options: -no-window -gpu swiftshader_indirect -no-audio -no-boot-anim -camera-back none
         api-level: 21
         arch: ${{matrix.abi}}
-        ndk: 29.0.14206865
+        ndk: ${{env.NDK_VERSION}}
         force-avd-creation: false
         disable-animations: false
         script: echo "Generated AVD snapshot for caching."
@@ -109,7 +114,7 @@ jobs:
         emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -no-audio -no-boot-anim -camera-back none
         api-level: 21
         arch: ${{matrix.abi}}
-        ndk: 29.0.14206865
+        ndk: ${{env.NDK_VERSION}}
         force-avd-creation: false
         disable-animations: true
         script: sh android.sh build test ${{matrix.abi}}

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ${{matrix.os}}
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         submodules: true
         lfs: true
@@ -41,7 +41,7 @@ jobs:
     runs-on: ${{matrix.os}}
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         submodules: true
         lfs: true

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -45,14 +45,14 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         submodules: true
         lfs: true
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v3
+      uses: github/codeql-action/init@v4
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -66,7 +66,7 @@ jobs:
     # Autobuild attempts to build any compiled languages (C/C++, C#, Go, Java, or Swift).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v3
+      uses: github/codeql-action/autobuild@v4
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
@@ -79,6 +79,6 @@ jobs:
     #     ./location_of_script_within_repo/buildscript.sh
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v3
+      uses: github/codeql-action/analyze@v4
       with:
         category: "/language:${{matrix.language}}"

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -24,14 +24,14 @@ jobs:
     steps:
     - name: get-cmake
       uses: lukka/get-cmake@v3.27.4
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         submodules: true
         lfs: true
     - name: Build ${{matrix.abi}}
       run: sh ios.sh build build-non-fat ${{matrix.sdk}} ${{matrix.abi}} $BUILD_TYPE
     - name: Archive artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: build-${{matrix.sdk}}-${{matrix.abi}}
         path: build
@@ -43,12 +43,12 @@ jobs:
     steps:
     - name: get-cmake
       uses: lukka/get-cmake@v3.27.4
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         submodules: true
         lfs: true
     - name: Download artifacts
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         path: build
         merge-multiple: true
@@ -61,14 +61,14 @@ jobs:
       run: ctest --test-dir build/iphonesimulator-arm64 -C $BUILD_TYPE
     - name: Archive artifacts (testsuite)
       if: ${{failure()}}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: testsuite
         path: ${{github.workspace}}/build/iphonesimulator-arm64/
     - name: Install fat files and XCFrameworks
       run: sh ios.sh build install "$HOME/ios" --config $BUILD_TYPE
     - name: Archive artifacts (xcframework)
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: xcframework
         path: ~/ios
@@ -78,7 +78,7 @@ jobs:
     timeout-minutes: 30
     if: ${{false}}
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         submodules: true
         lfs: true
@@ -89,7 +89,7 @@ jobs:
     - name: Install
       run: sh ios.sh build install $HOME/ios --config $BUILD_TYPE
     - name: Archive artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: ios
         path: ~/ios/

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ example:
 
 ```sh
 export ANDROID_HOME=/usr/local/lib/android/sdk
-export ANDROID_NDK=$ANDROID_HOME/ndk/25.2.9519653
+export ANDROID_NDK=$ANDROID_HOME/ndk/29.0.14206865
 ```
 
 Note that the value of `ANDROID_HOME` will vary depending on your environment,


### PR DESCRIPTION
- Updated ANDROID_NDK version to 29.0.14206865 in README.md and .github/workflows/android.yml.
- Updated GitHub Actions (checkout, upload-artifact, download-artifact, cache, codeql-action).
- Updated macOS runner from macos-13 to macos-latest in .github/workflows/android.yml.
- Updated macOS runner to macos-15-intel for Android test job to support emulator.